### PR TITLE
query: allow multiple session IDs per connection

### DIFF
--- a/src/query/socket.go
+++ b/src/query/socket.go
@@ -13,7 +13,7 @@ import (
 var (
 	socket        net.PacketConn   = nil
 	conf          *config.Config   = nil
-	sessions      map[int32]string = make(map[int32]string)
+	sessions      map[string]string = make(map[string]string) // Map of net.Addr.String() to challenge string
 	sessionsMutex *sync.Mutex      = &sync.Mutex{}
 )
 
@@ -76,7 +76,7 @@ func handlePacket(data []byte, addr net.Addr) {
 	switch packetType {
 	case 0x09: // Generate challenge token
 		{
-			if err = writeHandshakePacket(buf, sessionID); err != nil {
+			if err = writeHandshakePacket(buf, addr, sessionID); err != nil {
 				return
 			}
 
@@ -84,7 +84,7 @@ func handlePacket(data []byte, addr net.Addr) {
 		}
 	case 0x00: // Request
 		{
-			isFullStat, err := readRequestPacket(r, buf, sessionID)
+			isFullStat, err := readRequestPacket(r, buf, addr, sessionID)
 
 			if err != nil {
 				return


### PR DESCRIPTION
changes the sessions map to be keyed by socket address (stringified hostname+port) instead of session ID.

note: using net.Addr directly as a map key doesn't work since new, non-equal, net.Addr instances are created on each ReadFrom(). i don't know enough Go to know if this can be worked around.

fixes https://github.com/mcstatus-io/demo-server/issues/1

edit: this can be tested with https://pypi.org/project/mcstatus/